### PR TITLE
Adding End Date

### DIFF
--- a/news_manager/inc/posts.php
+++ b/news_manager/inc/posts.php
@@ -28,6 +28,7 @@ function nm_edit_post($slug = '') {
     $data    = @getXML($file);
     $title   = @stripslashes($data->title);
     $date    = isset($data->date) ? date('Y-m-d', strtotime($data->date)) : '';
+	$enddate = isset($data->enddate) ? date('Y-m-d', strtotime($data->enddate)) : '';
     $time    = isset($data->date) ? date('H:i', strtotime($data->date)) : '';
     $tags    = isset($data->tags) ? str_replace(',', ', ', stripslashes($data->tags)) : '';
     $private = @$data->private != '' ? 'checked' : '';
@@ -84,7 +85,9 @@ function nm_save_post() {
   # collect $_POST data
   $title     = safe_slash_html($_POST['post-title']);
   $timestamp = strtotime($_POST['post-date'] . ' ' . $_POST['post-time']);
+  $timestamp_end = strtotime($_POST['end-date'] . ' ' . $_POST['post-time']);
   $date      = $timestamp ? date('r', $timestamp) : date('r');
+  $end_date = $timestamp_end ? date('r', $timestamp_end) : date('r');
   $tags      = nm_lowercase_tags(trim(preg_replace(array('/\s+/','/\s*,\s*/','/,+/'),array(' ',',',','),safe_slash_html(trim($_POST['post-tags']))),','));
   $tags      = implode(',', array_unique(explode(',', $tags))); // remove dupe tags
   $private   = isset($_POST['post-private']) ? 'Y' : '';
@@ -104,6 +107,8 @@ function nm_save_post() {
   $obj->addCData($title);
   $obj = $xml->addChild('date');
   $obj->addCData($date);
+  $obj = $xml->addChild('enddate');
+  $obj->addCData($end_date);
   $obj = $xml->addChild('tags');
   $obj->addCData($tags);
   $obj = $xml->addChild('private');

--- a/news_manager/template/edit_post.php
+++ b/news_manager/template/edit_post.php
@@ -108,6 +108,12 @@ if ($imageinputpos > 0) {
         <input class="text short" id="post-time" name="post-time" type="text" value="<?php echo $time; ?>" />
       </p>
     </div>
+	<div class="leftopt">
+      <p>
+        <label for="end-date"><?php i18n('news_manager/END_DATE'); ?>:</label>
+        <input class="text short" id="end-date" name="end-date" type="text" value="<?php echo $enddate; ?>" />
+      </p>
+    </div>
     <div class="clear"></div>
     <style>#post-private { width:auto !important; } /* properly align checkbox - fix for GetSimple 3.1+ */</style>
     <div class="leftopt">


### PR DESCRIPTION
Had a project that needed both the use of publish dates and ending dates for news items. I created a new function that returned a list of news articles with ending dates in the future. I placed that function into a site specific plugin so updates to news manager wouldn't over write. It would be nice if you could merge or add something similar.
Thank you.